### PR TITLE
Update for meilisearch v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
     ],
     "require": {
         "php": "^8.0",
-        "meilisearch/meilisearch-php": "^0.21|^0.22|^0.23|^0.24|^0.25",
+        "meilisearch/meilisearch-php": "^1.0",
         "guzzlehttp/guzzle": "^7.3",
         "http-interop/http-factory-guzzle": "^1.0",
         "illuminate/support": "^8.0|^9.0",
-        "statamic/cms": "^3.1|^3.2|^3.3"
+        "statamic/cms": "^3.4"
     },
     "require-dev": {
         "orchestra/testbench-core": "^6.0|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
     },
     "config": {
         "allow-plugins": {
-            "pixelfear/composer-dist-plugin": true
+            "pixelfear/composer-dist-plugin": true,
+            "php-http/discovery": true
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "guzzlehttp/guzzle": "^7.3",
         "http-interop/http-factory-guzzle": "^1.0",
         "illuminate/support": "^8.0|^9.0",
-        "statamic/cms": "^3.4"
+        "statamic/cms": "^3.1|^3.2|^3.3|^3.4"
     },
     "require-dev": {
         "orchestra/testbench-core": "^6.0|^7.0",

--- a/src/MeiliSearch/Index.php
+++ b/src/MeiliSearch/Index.php
@@ -80,7 +80,12 @@ class Index extends BaseIndex
     {
         try {
             $this->client->createIndex($this->name, ['primaryKey' => 'id']);
-            $this->getIndex()->updateSettings($this->config['settings'] ?? []);
+
+            if (! isset($this->config['settings'])) {
+                return;
+            }
+
+            $this->getIndex()->updateSettings($this->config['settings']);
         } catch (ApiException $e) {
             $this->handleMeiliSearchException($e, 'createIndex');
         }


### PR DESCRIPTION
Made the package working with meilisearch-php version `1.0.0`, which was released on Feb 6. Fixed an issue where the settings couldnt be updated/set, because the `updateSettings()` method that internally patches `/indexes/{index_uid}/settings` didn't allow passing an empty array as `$settings` parameter. 